### PR TITLE
fixed comment regarding the global royalty fee

### DIFF
--- a/src/contracts/exchange/NiftyswapExchange20.sol
+++ b/src/contracts/exchange/NiftyswapExchange20.sol
@@ -856,7 +856,7 @@ contract NiftyswapExchange20 is ReentrancyGuard, ERC1155MintBurn, INiftyswapExch
 
   /**
    * @notice Will set the royalties fees and recipient for contracts that don't support ERC-2981
-   * @param _fee       Fee pourcentage with a 10000 basis (e.g. 0.3% is 3 and 1% is 10 and 100% is 1000)
+   * @param _fee       Fee pourcentage with a 10000 basis (e.g. 0.3% is 30 and 1% is 100 and 100% is 10000)
    * @param _recipient Address where to send the fees to
    */
   function setRoyaltyInfo(uint256 _fee, address _recipient) onlyOwner public {


### PR DESCRIPTION
- fixed a comment regarding the global royalty fee.
This error was discovered when noticing a discrepancy between the calculated royalty amount and the one that should be returned based on the content of this comment. We arrived at the conclusion that the problem was with the misleading comment.