### PR TITLE
Wrapper

### DIFF
--- a/src/contracts/interfaces/INiftyswapExchange20Wrapper.sol
+++ b/src/contracts/interfaces/INiftyswapExchange20Wrapper.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.4;
+
+interface INiftyswapExchange20Wrapper {
+    /**
+     * @notice Convert currency tokens to Tokens _id and transfers Tokens to recipient.
+     * @dev User specifies MAXIMUM inputs (_maxCurrency) and EXACT outputs.
+     * @dev Assumes that all trades will be successful, or revert the whole tx.
+     * @dev Exceeding currency tokens sent will be refunded to the currency recipient.
+     * @dev Sorting IDs is mandatory for efficient way of preventing duplicated IDs (which would lead to exploit)
+     * @param _exchange20Address   Address of the NiftyswapExchange20 contract
+     * @param _tokenIds            Array of Tokens ID that are bought
+     * @param _tokensBoughtAmounts Amount of Tokens id bought for each corresponding Token id in _tokenIds
+     * @param _maxCurrency         Total maximum amount of currency tokens to spend for all Token ids
+     * @param _deadline            Timestamp after which this transaction will be reverted
+     * @param _tokenRecipient      The address that receives output Tokens
+     * @param _currencyRecipient   The address that receives the refund of currency tokens
+     * @param _extraFeeRecipients  Array of addresses that will receive extra fee
+     * @param _extraFeeAmounts     Array of amounts of currency that will be sent as extra fee
+     * @return currencySold How much currency was actually sold.
+     */
+    function buyTokens(
+        address _exchange20Address,
+        uint256[] memory _tokenIds,
+        uint256[] memory _tokensBoughtAmounts,
+        uint256 _maxCurrency,
+        uint256 _deadline,
+        address _tokenRecipient,
+        address _currencyRecipient,
+        address[] memory _extraFeeRecipients,
+        uint256[] memory _extraFeeAmounts
+    ) external returns (uint256[] memory);
+}

--- a/src/contracts/wrapper/NiftyswapExchange20Wrapper.sol
+++ b/src/contracts/wrapper/NiftyswapExchange20Wrapper.sol
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.4;
+
+import {INiftyswapExchange20Wrapper} from "../interfaces/INiftyswapExchange20Wrapper.sol";
+import {INiftyswapExchange20} from "../interfaces/INiftyswapExchange20.sol";
+import {IERC20} from "@0xsequence/erc-1155/contracts/interfaces/IERC20.sol";
+import {IERC165} from "@0xsequence/erc-1155/contracts/interfaces/IERC165.sol";
+import {IERC1155} from "@0xsequence/erc-1155/contracts/interfaces/IERC1155.sol";
+import {IERC1155TokenReceiver} from "@0xsequence/erc-1155/contracts/interfaces/IERC1155TokenReceiver.sol";
+import {TransferHelper} from "@uniswap/lib/contracts/libraries/TransferHelper.sol";
+
+error InvalidRecipient();
+
+/**
+ * A wrapper for the Niiftyswap exchange contract that when swapping for ERC-1155
+ * allows the ERC-20 refund to be sent to a recipient other than the token recipient.
+ */
+contract NiftyswapExchange20Wrapper is INiftyswapExchange20Wrapper, IERC1155TokenReceiver, IERC165 {
+    // onReceive function signatures
+    bytes4 internal constant ERC1155_RECEIVED_VALUE = 0xf23a6e61;
+    bytes4 internal constant ERC1155_BATCH_RECEIVED_VALUE = 0xbc197c81;
+
+    address private tokenRecipient;
+
+    /**
+     * @notice Convert currency tokens to Tokens _id and transfers Tokens to recipient.
+     * @dev User specifies MAXIMUM inputs (_maxCurrency) and EXACT outputs.
+     * @dev Assumes that all trades will be successful, or revert the whole tx.
+     * @dev Exceeding currency tokens sent will be refunded to the currency recipient.
+     * @dev Sorting IDs is mandatory for efficient way of preventing duplicated IDs (which would lead to exploit)
+     * @param _exchange20Address   Address of the NiftyswapExchange20 contract
+     * @param _tokenIds            Array of Tokens ID that are bought
+     * @param _tokensBoughtAmounts Amount of Tokens id bought for each corresponding Token id in _tokenIds
+     * @param _maxCurrency         Total maximum amount of currency tokens to spend for all Token ids
+     * @param _deadline            Timestamp after which this transaction will be reverted
+     * @param _tokenRecipient      The address that receives output Tokens
+     * @param _currencyRecipient   The address that receives the refund of currency tokens
+     * @param _extraFeeRecipients  Array of addresses that will receive extra fee
+     * @param _extraFeeAmounts     Array of amounts of currency that will be sent as extra fee
+     * @return currencySold How much currency was actually sold.
+     */
+    function buyTokens(
+        address _exchange20Address,
+        uint256[] memory _tokenIds,
+        uint256[] memory _tokensBoughtAmounts,
+        uint256 _maxCurrency,
+        uint256 _deadline,
+        address _tokenRecipient,
+        address _currencyRecipient,
+        address[] memory _extraFeeRecipients,
+        uint256[] memory _extraFeeAmounts
+    ) external override returns (uint256[] memory currencySold) {
+        if (_currencyRecipient == address(0) || _tokenRecipient == address(0)) {
+            revert InvalidRecipient();
+        }
+
+        // Obtain currency for Niftyswap
+        address currencyAddress = INiftyswapExchange20(_exchange20Address).getCurrencyInfo();
+        TransferHelper.safeTransferFrom(currencyAddress, msg.sender, address(this), _maxCurrency);
+        TransferHelper.safeApprove(currencyAddress, _exchange20Address, _maxCurrency);
+
+        // Store recipient for forwarding
+        tokenRecipient = _tokenRecipient;
+
+        // Call NiftyswapExchange20 contract
+        currencySold = INiftyswapExchange20(_exchange20Address).buyTokens(
+            _tokenIds,
+            _tokensBoughtAmounts,
+            _maxCurrency,
+            _deadline,
+            address(this), // _tokenRecipient
+            _extraFeeRecipients,
+            _extraFeeAmounts
+        );
+
+        // Clear recipient
+        delete tokenRecipient;
+
+        // Send currency refund to currency recipient
+        uint256 balance = IERC20(currencyAddress).balanceOf(address(this));
+        TransferHelper.safeTransfer(currencyAddress, _currencyRecipient, balance);
+    }
+
+    /**
+     * Receive ERC-1155 tokens and forward to token recipient.
+     * @param _ids      An array containing ids of each Token being transferred
+     * @param _amounts  An array containing amounts of each Token being transferred
+     * @param _data     Additional data to forward to recipient
+     * @return bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)")
+     */
+    function onERC1155BatchReceived(
+        address, // _operator,
+        address, // from
+        uint256[] memory _ids,
+        uint256[] memory _amounts,
+        bytes memory _data
+    ) public override returns (bytes4) {
+        if (tokenRecipient == address(0)) {
+            revert InvalidRecipient();
+        }
+        // Forward to token recipient
+        IERC1155(msg.sender).safeBatchTransferFrom(address(this), tokenRecipient, _ids, _amounts, _data);
+        return ERC1155_BATCH_RECEIVED_VALUE;
+    }
+
+    /**
+     * Receive ERC-1155 tokens and forward to token recipient.
+     * @param _id      Id of Token being transferred
+     * @param _amount  Amounts of Token being transferred
+     * @param _data     Additional data to forward to recipient
+     * @return bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)")
+     */
+    function onERC1155Received(address, address, uint256 _id, uint256 _amount, bytes memory _data)
+        public
+        override
+        returns (bytes4)
+    {
+        if (tokenRecipient == address(0)) {
+            revert InvalidRecipient();
+        }
+        // Forward to token recipient
+        IERC1155(msg.sender).safeTransferFrom(address(this), tokenRecipient, _id, _amount, _data);
+        return ERC1155_RECEIVED_VALUE;
+    }
+
+    /**
+     * @notice Indicates which interfaces the contract implements.
+     * @param  interfaceID The ERC-165 interface ID that is queried for support.
+     * @return Whether a given interface is supported
+     */
+    function supportsInterface(bytes4 interfaceID) public pure override returns (bool) {
+        return interfaceID == type(INiftyswapExchange20Wrapper).interfaceId
+            || interfaceID == type(IERC1155TokenReceiver).interfaceId || interfaceID == type(IERC165).interfaceId;
+    }
+}

--- a/src/contracts/wrapper/NiftyswapExchange20Wrapper.sol
+++ b/src/contracts/wrapper/NiftyswapExchange20Wrapper.sol
@@ -12,7 +12,7 @@ import {TransferHelper} from "@uniswap/lib/contracts/libraries/TransferHelper.so
 error InvalidRecipient();
 
 /**
- * A wrapper for the Niiftyswap exchange contract that when swapping for ERC-1155
+ * A wrapper for the Niftyswap exchange contract that when swapping for ERC-1155
  * allows the ERC-20 refund to be sent to a recipient other than the token recipient.
  */
 contract NiftyswapExchange20Wrapper is INiftyswapExchange20Wrapper, IERC1155TokenReceiver, IERC165 {

--- a/tests_foundry/NiftyswapExchange20Wrapper.test.sol
+++ b/tests_foundry/NiftyswapExchange20Wrapper.test.sol
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.4;
+
+import {IERC165} from "@0xsequence/erc-1155/contracts/interfaces/IERC165.sol";
+import {IERC1155} from "@0xsequence/erc-1155/contracts/interfaces/IERC1155.sol";
+import {IERC1155TokenReceiver} from "@0xsequence/erc-1155/contracts/interfaces/IERC1155TokenReceiver.sol";
+
+import {INiftyswapExchange20} from "src/contracts/interfaces/INiftyswapExchange20.sol";
+import {NiftyswapFactory20} from "src/contracts/exchange/NiftyswapFactory20.sol";
+import {
+    NiftyswapExchange20Wrapper,
+    INiftyswapExchange20Wrapper,
+    InvalidRecipient
+} from "src/contracts/wrapper/NiftyswapExchange20Wrapper.sol";
+import {ERC1155Mock} from "src/contracts/mocks/ERC1155Mock.sol";
+import {ERC20TokenMock} from "src/contracts/mocks/ERC20TokenMock.sol";
+
+import {Niftyswap20TestHelper} from "./utils/Niftyswap20TestHelper.test.sol";
+import {console} from "forge-std/Test.sol";
+import {stdError} from "forge-std/StdError.sol";
+
+interface IERC1155Exchange is INiftyswapExchange20, IERC1155 {}
+
+contract NiftyswapExchange20WrapperTest is Niftyswap20TestHelper {
+    uint256[] private TOKEN_TYPES = [1, 2, 3];
+    uint256[] private TOKENS_PER_TYPE = [500000, 500000, 500000];
+
+    // Liquidity
+    uint256[] private CURRENCIES_PER_TYPE = [299 * 10e18, 299 * 10e18, 299 * 10e18];
+
+    // Fees
+    address[] private NO_ADDRESSES;
+    uint256[] private NO_FEES;
+
+    NiftyswapExchange20Wrapper private wrapper;
+    address private wrapperAddr;
+    address private exchangeAddr;
+    address private erc1155;
+    ERC20TokenMock private erc20Mock;
+    address private erc20;
+
+    function setUp() external {
+        wrapper = new NiftyswapExchange20Wrapper();
+        wrapperAddr = address(wrapper);
+
+        NiftyswapFactory20 factory = new NiftyswapFactory20(address(this));
+        ERC1155Mock erc1155Mock = new ERC1155Mock();
+        erc1155 = address(erc1155Mock);
+        erc20Mock = new ERC20TokenMock();
+        erc20 = address(erc20Mock);
+
+        factory.createExchange(erc1155, erc20, 100, 0);
+        exchangeAddr = factory.tokensToExchange(erc1155, erc20, 100, 0);
+        IERC1155Exchange exchange = IERC1155Exchange(exchangeAddr);
+
+        // Add liquidity
+        erc1155Mock.batchMintMock(OPERATOR, TOKEN_TYPES, TOKENS_PER_TYPE, "");
+        erc20Mock.mockMint(OPERATOR, 100000 ether);
+        vm.startPrank(OPERATOR);
+        erc20Mock.approve(exchangeAddr, 100000 ether);
+        erc1155Mock.safeBatchTransferFrom(
+            OPERATOR,
+            exchangeAddr,
+            TOKEN_TYPES,
+            TOKENS_PER_TYPE,
+            encodeAddLiquidity(CURRENCIES_PER_TYPE, block.timestamp)
+        );
+        vm.stopPrank();
+    }
+
+    //
+    // View
+    //
+
+    function test_supportsInterface() external {
+        IERC165 exc = IERC165(wrapperAddr);
+        assertTrue(
+            exc.supportsInterface(type(INiftyswapExchange20Wrapper).interfaceId), "INiftyswapExchange20Wrapper support"
+        );
+        assertTrue(exc.supportsInterface(type(IERC1155TokenReceiver).interfaceId), "IERC1155Receiver support");
+        assertTrue(exc.supportsInterface(type(IERC165).interfaceId), "IERC165 support");
+    }
+
+    //
+    // Buy
+    //
+
+    function test_buyTokens_happyPath(uint256[] memory tokens, uint256 refundAmount) public {
+        vm.assume(tokens.length > 2);
+        // Data
+        assembly {
+            // Set tokens to size 3
+            mstore(tokens, 3)
+        }
+        for (uint256 i; i < 3; i++) {
+            tokens[i] = _bound(tokens[i], 10, 1000);
+        }
+        uint256[] memory prices = IERC1155Exchange(exchangeAddr).getPrice_currencyToToken(TOKEN_TYPES, tokens);
+        uint256 totalPrice = getTotal(prices);
+        refundAmount = _bound(refundAmount, 0, 1 ether);
+
+        // ERC-20
+        withERC20(USER, totalPrice + refundAmount);
+
+        // Before bals
+        uint256 wrapperCurrBefore = erc20Mock.balanceOf(wrapperAddr);
+        uint256 exchangeCurrBefore = erc20Mock.balanceOf(exchangeAddr);
+        uint256 userCurrBefore = erc20Mock.balanceOf(USER);
+        uint256 recip2CurrBefore = erc20Mock.balanceOf(RECIPIENT_2);
+        uint256[] memory wrapperBalBefore = getBalances(wrapperAddr, TOKEN_TYPES, erc1155);
+        uint256[] memory exchangeBalBefore = getBalances(exchangeAddr, TOKEN_TYPES, erc1155);
+        uint256[] memory recip1BalBefore = getBalances(RECIPIENT_1, TOKEN_TYPES, erc1155);
+
+        // Run it
+        vm.prank(USER);
+        wrapper.buyTokens(
+            exchangeAddr,
+            TOKEN_TYPES,
+            tokens,
+            totalPrice + refundAmount,
+            block.timestamp,
+            RECIPIENT_1, // token recipient
+            RECIPIENT_2, // currency recipient
+            NO_ADDRESSES,
+            NO_FEES
+        );
+
+        // Check bals
+        {
+            uint256 wrapperCurrAfter = erc20Mock.balanceOf(wrapperAddr);
+            uint256[] memory wrapperBalAfter = getBalances(wrapperAddr, TOKEN_TYPES, erc1155);
+            assertEq(wrapperCurrAfter, wrapperCurrBefore);
+            assertSame(wrapperBalBefore, wrapperBalAfter);
+        }
+        {
+            uint256 exchangeCurrAfter = erc20Mock.balanceOf(exchangeAddr);
+            uint256[] memory exchangeBalAfter = getBalances(exchangeAddr, TOKEN_TYPES, erc1155);
+            assertEq(exchangeCurrAfter, exchangeCurrBefore + totalPrice); // Exchange currency rises
+            assertBeforeAfterDiff(exchangeBalBefore, exchangeBalAfter, tokens, false); // Exchange tokens drops
+        }
+        {
+            uint256 userCurrAfter = erc20Mock.balanceOf(USER);
+            assertEq(userCurrAfter, userCurrBefore - totalPrice - refundAmount); // User currency drops
+        }
+        {
+            uint256[] memory recip1BalAfter = getBalances(RECIPIENT_1, TOKEN_TYPES, erc1155);
+            assertBeforeAfterDiff(recip1BalBefore, recip1BalAfter, tokens, true); // Recipient 1 gets tokens
+        }
+        {
+            uint256 recip2CurrAfter = erc20Mock.balanceOf(RECIPIENT_2);
+            assertEq(recip2CurrAfter, recip2CurrBefore + refundAmount); // Recipient 2 gets refund
+        }
+    }
+
+    function test_buyTokens_happyPathRepeat(uint256 runs, uint256[] memory tokens, uint256 refundAmount) external {
+        runs = _bound(runs, 1, 10);
+        for (uint256 i; i < runs; i++) {
+            test_buyTokens_happyPath(tokens, refundAmount);
+        }
+    }
+
+    function test_buyTokens_invalidTokenRecipient(uint256[] memory tokens, uint256 refundAmount) external {
+        vm.assume(tokens.length > 2);
+        // Data
+        assembly {
+            // Set tokens to size 3
+            mstore(tokens, 3)
+        }
+        for (uint256 i; i < 3; i++) {
+            tokens[i] = _bound(tokens[i], 10, 1000);
+        }
+        uint256[] memory prices = IERC1155Exchange(exchangeAddr).getPrice_currencyToToken(TOKEN_TYPES, tokens);
+        uint256 totalPrice = getTotal(prices);
+        refundAmount = _bound(refundAmount, 0, 1 ether);
+
+        // ERC-20
+        withERC20(USER, totalPrice + refundAmount);
+
+        // Run it
+        vm.expectRevert(InvalidRecipient.selector);
+        vm.prank(USER);
+        wrapper.buyTokens(
+            exchangeAddr,
+            TOKEN_TYPES,
+            tokens,
+            totalPrice + refundAmount,
+            block.timestamp,
+            address(0), // token recipient
+            RECIPIENT_2, // currency recipient
+            NO_ADDRESSES,
+            NO_FEES
+        );
+    }
+
+    function test_buyTokens_invalidCurrencyRecipient(uint256[] memory tokens, uint256 refundAmount) external {
+        vm.assume(tokens.length > 2);
+        // Data
+        assembly {
+            // Set tokens to size 3
+            mstore(tokens, 3)
+        }
+        for (uint256 i; i < 3; i++) {
+            tokens[i] = _bound(tokens[i], 10, 1000);
+        }
+        uint256[] memory prices = IERC1155Exchange(exchangeAddr).getPrice_currencyToToken(TOKEN_TYPES, tokens);
+        uint256 totalPrice = getTotal(prices);
+        refundAmount = _bound(refundAmount, 0, 1 ether);
+
+        // ERC-20
+        withERC20(USER, totalPrice + refundAmount);
+
+        // Run it
+        vm.expectRevert(InvalidRecipient.selector);
+        vm.prank(USER);
+        wrapper.buyTokens(
+            exchangeAddr,
+            TOKEN_TYPES,
+            tokens,
+            totalPrice + refundAmount,
+            block.timestamp,
+            RECIPIENT_1, // token recipient
+            address(0), // currency recipient
+            NO_ADDRESSES,
+            NO_FEES
+        );
+    }
+
+    function test_buyTokens_invalidNiftyswapAddr(uint256[] memory tokens, uint256 refundAmount, address broken)
+        external
+    {
+        vm.assume(broken != exchangeAddr);
+        vm.assume(tokens.length > 2);
+        // Data
+        assembly {
+            // Set tokens to size 3
+            mstore(tokens, 3)
+        }
+        for (uint256 i; i < 3; i++) {
+            tokens[i] = _bound(tokens[i], 10, 1000);
+        }
+        uint256[] memory prices = IERC1155Exchange(exchangeAddr).getPrice_currencyToToken(TOKEN_TYPES, tokens);
+        uint256 totalPrice = getTotal(prices);
+        refundAmount = _bound(refundAmount, 0, 1 ether);
+
+        // ERC-20
+        withERC20(USER, totalPrice + refundAmount);
+
+        // Run it
+        vm.expectRevert();
+        vm.prank(USER);
+        wrapper.buyTokens(
+            broken,
+            TOKEN_TYPES,
+            tokens,
+            totalPrice + refundAmount,
+            block.timestamp,
+            RECIPIENT_1, // token recipient
+            RECIPIENT_2, // currency recipient
+            NO_ADDRESSES,
+            NO_FEES
+        );
+    }
+
+    //
+    // Helpers
+    //
+
+    function withERC20(address who, uint256 amount) internal {
+        erc20Mock.mockMint(who, amount);
+        vm.prank(who);
+        erc20Mock.approve(wrapperAddr, amount);
+    }
+}

--- a/tests_foundry/utils/Constants.test.sol
+++ b/tests_foundry/utils/Constants.test.sol
@@ -14,7 +14,4 @@ contract Constants {
     bytes4 internal constant ADDLIQUIDITY20_SIG = 0x82da2b73;
     bytes4 internal constant REMOVELIQUIDITY20_SIG = 0x5c0bf259;
     bytes4 internal constant DEPOSIT20_SIG = 0xc8c323f9;
-
-    address internal constant OPERATOR = address(1);
-    address internal constant USER = address(2);
 }

--- a/tests_foundry/utils/TestHelperBase.test.sol
+++ b/tests_foundry/utils/TestHelperBase.test.sol
@@ -8,6 +8,19 @@ import {Constants} from "./Constants.test.sol";
 import {Test} from "forge-std/Test.sol";
 
 abstract contract TestHelperBase is Test, Constants {
+    address internal immutable OPERATOR;
+    address internal immutable USER;
+    address internal immutable RECIPIENT_1;
+    address internal immutable RECIPIENT_2;
+
+    constructor() {
+        // Set up test
+        OPERATOR = makeAddr("OPERATOR");
+        USER = makeAddr("USER");
+        RECIPIENT_1 = makeAddr("RECIPIENT_1");
+        RECIPIENT_2 = makeAddr("RECIPIENT_2");
+    }
+
     /**
      * Get token balances.
      */
@@ -16,10 +29,11 @@ abstract contract TestHelperBase is Test, Constants {
         view
         returns (uint256[] memory balances)
     {
-        balances = new uint256[](types.length);
+        address[] memory owners = new address[](types.length);
         for (uint256 i; i < types.length; i++) {
-            balances[i] = IERC1155(erc1155).balanceOf(owner, types[i]);
+            owners[i] = owner;
         }
+        balances = IERC1155(erc1155).balanceOfBatch(owners, types);
         return balances;
     }
 


### PR DESCRIPTION
Adds a wrapper for the Niiftyswap exchange 20 contract that when swapping for ERC-1155 allows the ERC-20 refund to be sent to a recipient other than the token recipient.